### PR TITLE
Uploading in a UI bound to non root path does not work

### DIFF
--- a/vaadin-plupload/src/main/java/pl/exsio/plupload/PluploadReceiver.java
+++ b/vaadin-plupload/src/main/java/pl/exsio/plupload/PluploadReceiver.java
@@ -80,7 +80,7 @@ public class PluploadReceiver implements RequestHandler, Serializable {
 
     @Override
     public boolean handleRequest(VaadinSession session, VaadinRequest request, VaadinResponse response) throws IOException {
-        if (UPLOAD_ACTION_PATH.equals(request.getPathInfo().replaceAll("/", ""))) {
+        if (request.getPathInfo() != null && request.getPathInfo().endsWith(UPLOAD_ACTION_PATH)) {
             if (request instanceof VaadinServletRequest) {
                 VaadinServletRequest vsr = (VaadinServletRequest) request;
                 HttpServletRequest req = vsr.getHttpServletRequest();


### PR DESCRIPTION
I'm working with more than one Vaadin UI. The UI using this addon is bound to the path "/s/" and the addon's request results in "/s/pluploader-upload-action".

The PR changes the behavior of the PluploadReceiver slightly and now accepts requests from different UIs.
