### PR TITLE
Remove the margin from PluploadFields wrapper component

### DIFF
--- a/vaadin-plupload/src/main/java/pl/exsio/plupload/field/PluploadField.java
+++ b/vaadin-plupload/src/main/java/pl/exsio/plupload/field/PluploadField.java
@@ -81,7 +81,6 @@ public class PluploadField<T extends Object> extends CustomField<T> {
     protected Component initContent() {
 
         this.layout = new HorizontalLayout();
-        this.layout.setMargin(true);
         this.layout.setSpacing(true);
 
         this.uploader.setMultiSelection(false);


### PR DESCRIPTION
I'm using the PluploadField in a FormLayout and Valo theming. The setMargin(true) on the HorizontalLayout puts a little to much "margin" around the component and therefore it does not look good in my layout.

As a alternative or addition it might be a good idea to add style names the the various components of this field. What do you think.
